### PR TITLE
Introduce placeholders in translation strings

### DIFF
--- a/app/src/main/java/org/bobstuff/bobball/BobBallActivity.java
+++ b/app/src/main/java/org/bobstuff/bobball/BobBallActivity.java
@@ -174,7 +174,7 @@ public class BobBallActivity extends Activity implements SurfaceHolder.Callback,
             gameView.draw(canvas, currGameState);
             if (gameLoop.iteration % ITERATIONS_PER_STATUSUPDATE == 0) {
 
-                SpannableString timeLeftStr = SpannableString.valueOf(getString(R.string.timeLeftLabel) + gameManager.timeLeft() / 10);
+                SpannableString timeLeftStr = SpannableString.valueOf(getString(R.string.timeLeftLabel), gameManager.timeLeft() / 10);
                 SpannableStringBuilder livesStr = formatPerPlayer(getString(R.string.livesLabel), new playstat() {
                     @Override
                     public int call(Player p) {
@@ -250,7 +250,7 @@ public class BobBallActivity extends Activity implements SurfaceHolder.Callback,
     }
 
     private void showWonScreen() {
-        messageView.setText(getString(R.string.levelCompleted) + gameManager.getLevel());
+        messageView.setText(getString(R.string.levelCompleted, gameManager.getLevel());
         button.setText("NEXT LEVEL");
         setMessageViewsVisible(true);
         activityState = ActivityStateEnum.GAMEWON;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,10 +6,10 @@
     <string name="pausedText">paused</string>
     <string name="bttnTextResume">resume playing</string>
     <string name="welcomeText">Welcome to BobBall</string>
-    <string name="levelCompleted">"Well done, you have completed level "</string>
+    <string name="levelCompleted">"Well done, you have completed level %d"</string>
     <string name="dead">You are dead</string>
     <string name="namePrompt">Enter your name:</string>
-    <string name="timeLeftLabel">"Time Left: "</string>
+    <string name="timeLeftLabel">"Time Left: %d"</string>
     <string name="livesLabel">"Lives: "</string>
     <string name="scoreLabel">"Score: "</string>
     <string name="areaClearedLabel">"% Cleared: "</string>


### PR DESCRIPTION
I improved the translation strings so that it uses placeholders. So you can use more flexible sentence structures, as mentioned in #16.
