### PR TITLE
fix game pause

### DIFF
--- a/app/src/main/java/org/bobstuff/bobball/GameLogic/GameManager.java
+++ b/app/src/main/java/org/bobstuff/bobball/GameLogic/GameManager.java
@@ -36,9 +36,9 @@ public class GameManager implements Parcelable, Runnable {
     public static final int CHECKPOINT_FREQ = 32;
     public static final int PERCENT_COMPLETED = 75;
     public static final float NUMBER_OF_UPDATES_PER_SECOND = 240;
-
     public static int LEVEL_DURATION_TICKS = 12500;
 
+    private boolean paused = false;
     private int seed;
 
     private Deque<GameState> gameStates;
@@ -72,6 +72,13 @@ public class GameManager implements Parcelable, Runnable {
         return getCurrGameState().getGrid();
     }
 
+    public void togglePauseGameLoop (){
+        paused = ! paused;
+    }
+
+    public boolean getPauseStatus (){
+        return paused;
+    }
 
     // clear the even queues
     // emit a new game event
@@ -228,7 +235,9 @@ public class GameManager implements Parcelable, Runnable {
 
     @Override
     public void run() {
-        singleStepGameLoop();
+        if (! paused) {
+            singleStepGameLoop();
+        }
     }
 
     public synchronized void singleStepGameLoop() {

--- a/app/src/main/java/org/bobstuff/bobball/GameLogic/GameManager.java
+++ b/app/src/main/java/org/bobstuff/bobball/GameLogic/GameManager.java
@@ -182,6 +182,18 @@ public class GameManager implements Parcelable, Runnable {
         }
     }
 
+    public boolean allBarsFinished (GameState gameState){
+        List<Player> players = gameState.getPlayers();
+        for (int playerId = 0; playerId < players.size(); playerId++){
+            Player player = players.get(playerId);
+
+            if (player.bar.getSectionOne() != null || player.bar.getSectionTwo() != null){
+                return false;
+            }
+        }
+        return true;
+    }
+
 
     public synchronized void addEvent(GameEvent ev) {
         pendingGameEv.addEvent(ev);
@@ -244,7 +256,7 @@ public class GameManager implements Parcelable, Runnable {
 
         GameState gs = getCurrGameState();
 
-        if (gameGetOutcome(gs) != 0) //won or lost
+        if (gameGetOutcome(gs) != 0 && allBarsFinished(gs)) //won or lost
             return;
 
         //rollback necessary?

--- a/app/src/main/java/org/bobstuff/bobball/Menus/menuHighScores.java
+++ b/app/src/main/java/org/bobstuff/bobball/Menus/menuHighScores.java
@@ -124,7 +124,7 @@ public class menuHighScores extends Activity {
     public void retry (View view){
         int retryAction = Settings.getRetryAction();
         Intent intent = new Intent(this, BobBallActivity.class);
-        int numPlayers = Settings.getNumPlayers() + 1;
+        int numPlayers = Settings.getNumPlayers();
         finish();   // finish in any case, finish only for retryAction 0 (Go back to level select)
 
         if (retryAction == 1){  // restart last level lost, same numPlayers

--- a/app/src/main/java/org/bobstuff/bobball/Menus/menuSinglePlayer.java
+++ b/app/src/main/java/org/bobstuff/bobball/Menus/menuSinglePlayer.java
@@ -58,7 +58,7 @@ public class menuSinglePlayer extends Activity {
 
                 int numPlayers = position + 1;
 
-                Settings.setNumPlayers(numPlayers - 1);
+                Settings.setNumPlayers(numPlayers);
 
                 int highestLevel = Statistics.getHighestLevel(numPlayers);
 

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -102,6 +102,26 @@
                 android:gravity="center"
                 android:layout_marginBottom="10sp"/>
 
+            <TextView
+                android:id="@+id/percentageCleared"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                android:textColor="#fff"
+                android:textStyle="bold"
+                android:layout_marginBottom="10sp"
+                android:visibility="gone"/>
+
+            <TextView
+                android:id="@+id/bonusPoints"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                android:textColor="#fff"
+                android:textStyle="bold"
+                android:layout_marginBottom="10sp"
+                android:visibility="gone"/>
+
             <Button
                 android:id="@+id/continue_button"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -86,7 +86,7 @@
 
         <LinearLayout
             android:id="@+id/message_layout"
-            android:layout_width="200dip"
+            android:layout_width="205dip"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:layout_centerInParent="true">

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,6 +24,8 @@
 		<!-- won menu -->
 		<string name="levelCompleted">"Gut gemacht, du hast Level %d beendet"</string>
 		<string name="nextLevel">NÄCHSTES LEVEL</string>
+		<string name="percentageCleared">Bereinigt:</string>
+		<string name="bonusPoints">Bonus: %d</string>
 
 		<!-- lost menu -->
 		<string name="dead">Du bist gestorben</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -33,6 +33,8 @@
 		<!-- won menu -->
 		<string name="levelCompleted">"Well done, you have completed level %d"</string>
 		<string name="nextLevel">NEXT LEVEL</string>
+		<string name="percentageCleared">Cleared:</string>
+		<string name="bonusPoints">Bonus: %d</string>
 
 		<!-- lost menu -->
 		<string name="dead">You are dead</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
         <!-- won menu -->
         <string name="levelCompleted">"Well done, you have completed level %d"</string>
         <string name="nextLevel">NEXT LEVEL</string>
+        <string name="percentageCleared">Cleared:</string>
+        <string name="bonusPoints">Bonus: %d</string>
 
         <!-- lost menu -->
         <string name="dead">You are dead</string>


### PR DESCRIPTION
When the pause menu was opened, the game continued in background. This is now fixed. Also fixed #15 by making the game wait until all bars finish before switching to the "next level" screen and adding the cleared percentage as well as the bonus points to the "next level" screen.
