### PR TITLE
Fix game pause

### DIFF
--- a/app/src/main/java/org/bobstuff/bobball/BobBallActivity.java
+++ b/app/src/main/java/org/bobstuff/bobball/BobBallActivity.java
@@ -124,6 +124,9 @@ public class BobBallActivity extends Activity implements SurfaceHolder.Callback,
             @Override
             public void onDrawerClosed(View drawerView) {
                 super.onDrawerClosed(drawerView);
+                if (gameManager.isPaused()) {
+                    gameManager.togglePauseGameLoop();
+                }
                 changeToPauseScreen();
                 onClick(drawerView);
             }
@@ -131,10 +134,13 @@ public class BobBallActivity extends Activity implements SurfaceHolder.Callback,
             @Override
             public void onDrawerOpened(View drawerView) {
                 super.onDrawerOpened(drawerView);
-                if (activityState == ActivityStateEnum.GAMERUNNING)
+                if (activityState == ActivityStateEnum.GAMERUNNING) {
+                    if (! gameManager.isPaused()) {
+                        gameManager.togglePauseGameLoop();
+                    }
                     showPauseScreen();
+                }
             }
-
         });
 
         drawerLayout.setFocusableInTouchMode(false);    // if set to false, the drawer doesn't react to pressing the back key by default

--- a/app/src/main/java/org/bobstuff/bobball/GameLogic/GameManager.java
+++ b/app/src/main/java/org/bobstuff/bobball/GameLogic/GameManager.java
@@ -36,9 +36,9 @@ public class GameManager implements Parcelable, Runnable {
     public static final int CHECKPOINT_FREQ = 32;
     public static final int PERCENT_COMPLETED = 75;
     public static final float NUMBER_OF_UPDATES_PER_SECOND = 240;
-
     public static int LEVEL_DURATION_TICKS = 12500;
 
+    private boolean paused = false;
     private int seed;
 
     private Deque<GameState> gameStates;
@@ -72,6 +72,13 @@ public class GameManager implements Parcelable, Runnable {
         return getCurrGameState().getGrid();
     }
 
+    public void togglePauseGameLoop (){
+        paused = ! paused;
+    }
+
+    public boolean isPaused(){
+        return paused;
+    }
 
     // clear the even queues
     // emit a new game event
@@ -114,39 +121,42 @@ public class GameManager implements Parcelable, Runnable {
         }
     }
 
+    public synchronized int getBonusPoints (GameState gs, Player player){
+        int playerId = player.getPlayerId();
+        int timeLeft = timeLeft(gs);
+        float percentComplete = gs.getGrid().getPercentCompleteFloat(player.getPlayerId());
+        int remainingLifes = player.getLives();
+        int lostLifes = gs.level + 1 - remainingLifes;
+
+        return Math.round((percentComplete * (timeLeft / 1000)) * gs.level);
+    }
 
     public synchronized void nextLevel() {
         GameState gs = getCurrGameState();
         int level = gs.level;
 
-        LEVEL_DURATION_TICKS += 2500;
-
         //update scores
         for (Player player : gs.getPlayers()) {
             if (player.level < gs.level) // update score
                 if (player.getLives() > 0) {
-                    int playerId = player.getPlayerId();
-                    int timeLeft = GameManager.timeLeft(gs);
-                    int percentComplete = gs.getGrid().getPercentComplete(player.getPlayerId());
-                    int levelFinished = gs.level;
-                    int remainingLifes = player.getLives();
-                    int lostLifes = levelFinished + 1 - remainingLifes;
-                    int score = (percentComplete * (timeLeft / 1000)) * levelFinished;
 
-                    if (playerId == 1){
-                        Statistics.saveHighestLevelScore(score);
-                        Statistics.saveTimeLeftRecord(timeLeft / 10);
-                        Statistics.saveLeastTimeLeft(timeLeft / 10);
-                        Statistics.savePercentageClearedRecord(percentComplete);
-                        Statistics.saveLivesLeftRecord(remainingLifes);
+                    int bonus = getBonusPoints (gs, player);
+
+                    if (player.getPlayerId() == 1){
+                        Statistics.saveHighestLevelScore(bonus);
+                        Statistics.saveTimeLeftRecord(timeLeft(gs) / 10);
+                        Statistics.saveLeastTimeLeft(timeLeft(gs) / 10);
+                        Statistics.savePercentageClearedRecord(gs.getGrid().getPercentCompleteFloat(player.getPlayerId()));
+                        Statistics.saveLivesLeftRecord(player.getLives());
                     }
 
-                    player.setScore(player.getScore() + score);
+                    player.setScore(player.getScore() + bonus);
                 }
         }
 
         gs = new GameState(gs.getPlayers());
         gs.level = level + 1;
+        LEVEL_DURATION_TICKS += 2500;
 
         gameStates.clear();
         gameStates.addFirst(gs); // fresh gamestate with old players
@@ -173,6 +183,18 @@ public class GameManager implements Parcelable, Runnable {
             }
             grid.checkEmptyAreas(balls, playerid);
         }
+    }
+
+    public boolean allBarsFinished (GameState gameState){
+        List<Player> players = gameState.getPlayers();
+        for (int playerId = 0; playerId < players.size(); playerId++){
+            Player player = players.get(playerId);
+
+            if (player.bar.getSectionOne() != null || player.bar.getSectionTwo() != null){
+                return false;
+            }
+        }
+        return true;
     }
 
 
@@ -228,14 +250,16 @@ public class GameManager implements Parcelable, Runnable {
 
     @Override
     public void run() {
-        singleStepGameLoop();
+        if (! paused) {
+            singleStepGameLoop();
+        }
     }
 
     public synchronized void singleStepGameLoop() {
 
         GameState gs = getCurrGameState();
 
-        if (gameGetOutcome(gs) != 0) //won or lost
+        if (gameGetOutcome(gs) != 0 && allBarsFinished(gs)) //won or lost
             return;
 
         //rollback necessary?
@@ -260,8 +284,8 @@ public class GameManager implements Parcelable, Runnable {
                 addCheckpoint(gameStates);
             }
         }
-        setGameTime(getGameTime() + 1);
 
+        setGameTime(getGameTime() + 1);
 
         /*if (gs.time % 200 == 0) {
             Log.d(TAG, "pending now=" + gameTime + "  " + pendingGameEv);

--- a/app/src/main/java/org/bobstuff/bobball/GameLogic/Grid.java
+++ b/app/src/main/java/org/bobstuff/bobball/GameLogic/Grid.java
@@ -125,6 +125,14 @@ public class Grid implements Parcelable {
         return (totalFilledGridSquares * 100) / totalGridSquares;
     }
 
+    public float getPercentCompleteFloat (int playerId) {
+        return (float) Math.round(((perPlayer.get(playerId).filledGridSquares) * 100 * 100) / totalGridSquares) / 100;
+    }
+
+    public float getPercentCompleteFloat () {
+        return (float) Math.round((totalFilledGridSquares * 100 * 100) / totalGridSquares) / 100;
+    }
+
     public float getWidth() {
         return (maxX - 1);
     }

--- a/app/src/main/java/org/bobstuff/bobball/Menus/menuHighScores.java
+++ b/app/src/main/java/org/bobstuff/bobball/Menus/menuHighScores.java
@@ -124,7 +124,7 @@ public class menuHighScores extends Activity {
     public void retry (View view){
         int retryAction = Settings.getRetryAction();
         Intent intent = new Intent(this, BobBallActivity.class);
-        int numPlayers = Settings.getNumPlayers() + 1;
+        int numPlayers = Settings.getNumPlayers();
         finish();   // finish in any case, finish only for retryAction 0 (Go back to level select)
 
         if (retryAction == 1){  // restart last level lost, same numPlayers

--- a/app/src/main/java/org/bobstuff/bobball/Menus/menuSinglePlayer.java
+++ b/app/src/main/java/org/bobstuff/bobball/Menus/menuSinglePlayer.java
@@ -58,7 +58,7 @@ public class menuSinglePlayer extends Activity {
 
                 int numPlayers = position + 1;
 
-                Settings.setNumPlayers(numPlayers - 1);
+                Settings.setNumPlayers(numPlayers);
 
                 int highestLevel = Statistics.getHighestLevel(numPlayers);
 

--- a/app/src/main/java/org/bobstuff/bobball/Menus/menuStatistics.java
+++ b/app/src/main/java/org/bobstuff/bobball/Menus/menuStatistics.java
@@ -25,7 +25,7 @@ public class menuStatistics extends Activity {
         String highestLevelScoreText = getString(R.string.highestLevelScoreText, Statistics.getHighestLevelScore());
         String topScoreText = getString(R.string.topScoreText, Statistics.getTopScore());
         String timeLeftRecordText = getString(R.string.timeLeftRecordText, Statistics.getTimeLeftRecord());
-        String percentageClearedRecordText = getString(R.string.percentageClearedText, Statistics.getPercentageClearedRecord());
+        String percentageClearedRecordText = getString(R.string.percentageClearedText, Statistics.getPercentageClearedRecord() + "%");
         String livesLeftRecordText = getString(R.string.livesLeftRecordText, Statistics.getLivesLeftRecord());
         String leastTimeLeftText = getString(R.string.leastTimeLeftText, Statistics.getLeastTimeLeft());
 

--- a/app/src/main/java/org/bobstuff/bobball/Statistics.java
+++ b/app/src/main/java/org/bobstuff/bobball/Statistics.java
@@ -128,16 +128,16 @@ public class Statistics {
 
     // highest percentage cleared for one level
 
-    public static void setPercentageClearedRecord(int percentageCleared){
+    public static void setPercentageClearedRecord(float percentageCleared){
         Preferences.saveValue("percentageCleared","" + percentageCleared);
     }
 
-    public static int getPercentageClearedRecord(){
-        return Integer.parseInt(Preferences.loadValue("percentageCleared","0"));
+    public static float getPercentageClearedRecord(){
+        return Float.parseFloat(Preferences.loadValue("percentageCleared","0"));
     }
 
-    public static void savePercentageClearedRecord (int percentageCleared){
-        int currentRecord = getPercentageClearedRecord();
+    public static void savePercentageClearedRecord (float percentageCleared){
+        float currentRecord = getPercentageClearedRecord();
 
         if (currentRecord < percentageCleared){
             setPercentageClearedRecord(percentageCleared);

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -86,7 +86,7 @@
 
         <LinearLayout
             android:id="@+id/message_layout"
-            android:layout_width="200dip"
+            android:layout_width="205dip"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:layout_centerInParent="true">
@@ -101,6 +101,35 @@
                 android:textStyle="bold"
                 android:gravity="center"
                 android:layout_marginBottom="10sp"/>
+
+            <TextView
+                android:id="@+id/percentageCleared"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                android:textColor="#fff"
+                android:textStyle="bold"
+                android:visibility="gone"/>
+
+            <TextView
+                android:id="@+id/totalPercentageCleared"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                android:textColor="#fff"
+                android:textStyle="bold"
+                android:visibility="gone"/>
+
+            <TextView
+                android:id="@+id/bonusPoints"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                android:textColor="#fff"
+                android:textStyle="bold"
+                android:layout_marginTop="10sp"
+                android:layout_marginBottom="10sp"
+                android:visibility="gone"/>
 
             <Button
                 android:id="@+id/continue_button"

--- a/app/src/main/res/layout/menu_options.xml
+++ b/app/src/main/res/layout/menu_options.xml
@@ -51,7 +51,9 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:background="@drawable/border_bottom"
-                    android:textColor="#fff" />
+                    android:textColor="#fff"
+                    android:imeOptions="actionDone"
+                    android:singleLine="true"/>
 
             </LinearLayout>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,6 +24,9 @@
 		<!-- won menu -->
 		<string name="levelCompleted">"Gut gemacht, du hast Level %d beendet"</string>
 		<string name="nextLevel">NÄCHSTES LEVEL</string>
+		<string name="percentageCleared">Bereinigt: %s</string>
+		<string name="totalPercentageCleared">Gesamt: %s</string>
+		<string name="bonusPoints">Bonus: %d</string>
 
 		<!-- lost menu -->
 		<string name="dead">Du bist gestorben</string>
@@ -100,7 +103,7 @@
 	<string name="highestLevelScoreText">Höchste Level Punktzahl: %d</string>
 	<string name="topScoreText">Höchste Gesamtpunktzahl: %d</string>
 	<string name="timeLeftRecordText">Meiste übrige Zeit: %d</string>
-	<string name="percentageClearedText">Meistes bereinigt: %d</string>
+	<string name="percentageClearedText">Meistes bereinigt: %s</string>
 	<string name="livesLeftRecordText">Meiste übrige Leben: %d</string>
 	<string name="leastTimeLeftText">Wenigste übrige Zeit: %d</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -33,6 +33,8 @@
 		<!-- won menu -->
 		<string name="levelCompleted">"Well done, you have completed level %d"</string>
 		<string name="nextLevel">NEXT LEVEL</string>
+		<string name="percentageCleared">Cleared: %s</string>
+		<string name="bonusPoints">Bonus: %d</string>
 
 		<!-- lost menu -->
 		<string name="dead">You are dead</string>
@@ -108,7 +110,7 @@
 	<string name="highestLevelScoreText">Highest level score: %d</string>
 	<string name="topScoreText">Highest total score: %d</string>
 	<string name="timeLeftRecordText">Most time left: %d</string>
-	<string name="percentageClearedText">Most cleared: %d</string>
+	<string name="percentageClearedText">Most cleared: %s</string>
 	<string name="livesLeftRecordText">Most lives left: %d</string>
 	<string name="leastTimeLeftText">Least time left: %d</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
         <!-- won menu -->
         <string name="levelCompleted">"Well done, you have completed level %d"</string>
         <string name="nextLevel">NEXT LEVEL</string>
+        <string name="percentageCleared">Cleared: %s</string>
+        <string name="totalPercentageCleared">Total: %s</string>
+        <string name="bonusPoints">Bonus: %d</string>
 
         <!-- lost menu -->
         <string name="dead">You are dead</string>
@@ -99,7 +102,7 @@
     <string name="highestLevelScoreText">Highest level score: %d</string>
     <string name="topScoreText">Highest total score: %d</string>
     <string name="timeLeftRecordText">Most time left: %d</string>
-    <string name="percentageClearedText">Most cleared: %d</string>
+    <string name="percentageClearedText">Most cleared: %s</string>
     <string name="livesLeftRecordText">Most lives left: %d</string>
     <string name="leastTimeLeftText">Least time left: %d</string>
 


### PR DESCRIPTION
When the pause menu was opened, the game continued in background. This is now fixed. Also fixed #15 by making the game wait until all bars finish before switching to the "next level" screen and adding the cleared percentage as well as the bonus points to the "next level" screen.

I closed the old pull request because I thought it wasn't merged because of the huge amount of commits. Therefore I tried to reduce the number of commits by comitting all changes at once in one file instead of adding the changes separately because I forgot something or had a new idea.
